### PR TITLE
Fixes SettingsPane's minimal size bug

### DIFF
--- a/addons/SEAL/plugin.cfg
+++ b/addons/SEAL/plugin.cfg
@@ -2,6 +2,6 @@
 
 name="SEAL (Settings Encapsulation and Abstraction Layer)"
 description="SEAL aims to provide a flexible library for easily implementing settings into your project while keeping the API and implementation flexible, simple & thin enough to accomodate needs beyond the basics with minimum effort, while keeping simplicity. The aim is to provide a library that is easy to set up initially and still grow together with your project through making it simple to implement custom features and expand on the native behaviour of the plugin."
-author="albinaask"
+author="albinaask, LightTab2"
 version="1.0"
 script="plugin.gd"

--- a/addons/SEAL/visualizers/SettingsPanel.gd
+++ b/addons/SEAL/visualizers/SettingsPanel.gd
@@ -97,7 +97,7 @@ func _update_visuals():
 
 func _update_min_size():
 	var min_size_x = 0
-	for child in get_children():
+	for child in $SettingsPane/VBoxContainer.get_children():
 		if child is Control:
 			min_size_x = max(min_size_x, child.get_combined_minimum_size().x)
 	$SettingsPane/VBoxContainer.custom_minimum_size.x = min_size_x

--- a/addons/SEAL/visualizers/SettingsPanel.tscn
+++ b/addons/SEAL/visualizers/SettingsPanel.tscn
@@ -26,6 +26,7 @@ layout_mode = 2
 placeholder_text = "search"
 
 [node name="SettingsPane" type="ScrollContainer" parent="."]
+custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0


### PR DESCRIPTION
Fixes #4.

`$SettingsPane/VBoxContainer` calculates its minimal size based only on its children.