### PR TITLE
Adds a customizable Group Button

### DIFF
--- a/addons/SEAL/painters/GroupButtonPainter.gd
+++ b/addons/SEAL/painters/GroupButtonPainter.gd
@@ -1,0 +1,45 @@
+extends Button
+
+##Forces a minimal size to fit the text, icon and separation between those
+@export var set_minimum_size : bool = true 
+
+##Calculates minimal size to fit the text, icon and separation between those
+func calc_min_size() -> void:
+	if !self.set_minimum_size:
+		return
+	
+	var font = self.get_theme_font("font")
+	var font_size = self.get_theme_font_size("font_size")
+	var text_width = 0.0
+	var h_separation = 4.0
+	var icon_width = self.icon.get_width() * self.size.y/self.icon.get_height()
+	
+	if !font:
+		font = self.get_theme_default_font()
+		font_size = self.get_theme_default_font_size()
+	
+	if font:
+		text_width = font.get_string_size(self.text, 0, -1, font_size).x
+	
+	if self.get("theme_constants/h_separation") != null:
+		h_separation = self.get("theme_constants/h_separation")
+	if self.get("theme_override_constants/h_separation") != null:
+		h_separation = self.get("theme_override_constants/h_separation")
+		
+	self.custom_minimum_size.x = text_width + h_separation + icon_width
+
+#Just so the user doesn't need to look into the code and learn they need to manually set the size's x to 0
+##Helper function to disable minimum size calculation
+func disable_calc_min_size():
+	self.set_minimum_size = false
+	self.custom_minimum_size.x = 0
+
+##Make sure if a theme override occurs, the min size is recalculated 
+func _ontheme_changed() -> void:
+	#Could use some checks to not add additional work if not needed, but these aren't usually critical
+	self.calc_min_size()
+
+##Make sure if an override occurs, the min size is recalculated 
+func _onproperty_list_changed() -> void:
+	#Could use some checks to not add additional work if not needed, but these aren't usually critical
+	self.calc_min_size()

--- a/addons/SEAL/painters/GroupButtonPainter.tscn
+++ b/addons/SEAL/painters/GroupButtonPainter.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=3 uid="uid://cb6q84y2tkgs3"]
+
+[ext_resource type="Texture2D" uid="uid://dr06uhafck2br" path="res://addons/SEAL/visualizers/OpenSectionIcon.png" id="1_gcpg4"]
+[ext_resource type="Script" path="res://addons/SEAL/painters/GroupButtonPainter.gd" id="2_tne75"]
+
+[node name="GroupButtonPainter" type="Button"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 0
+focus_mode = 1
+theme_override_constants/h_separation = 20
+icon = ExtResource("1_gcpg4")
+flat = true
+alignment = 0
+expand_icon = true
+script = ExtResource("2_tne75")
+
+[connection signal="property_list_changed" from="." to="." method="_onproperty_list_changed"]
+[connection signal="theme_changed" from="." to="." method="_ontheme_changed"]

--- a/addons/SEAL/painters/SettingsPainter.gd
+++ b/addons/SEAL/painters/SettingsPainter.gd
@@ -71,7 +71,7 @@ func _get_minimum_size() -> Vector2:
 
 #Set correct positions of children.
 func _sort_children():
-	assert(settings_panel, "Settings panel not set, must be set befoere added to tree.")
+	assert(settings_panel, "Settings panel not set, must be set before added to tree.")
 	if _title_label && _value_group && _reset_button:
 		var margin = settings_panel.margin
 

--- a/addons/SEAL/visualizers/SettingsPanel.gd
+++ b/addons/SEAL/visualizers/SettingsPanel.gd
@@ -2,6 +2,8 @@ extends VBoxContainer
 
 class_name SettingsPanel
 
+const GROUP_BUTTON_PAINTER : PackedScene = preload("res://addons/SEAL/painters/GroupButtonPainter.tscn")
+
 ##Icon that will be shown when the group is not collapsed.
 @export var open_section_icon: Texture2D = preload("res://addons/SEAL/visualizers/OpenSectionIcon.png")
 
@@ -56,19 +58,15 @@ func _on_panel_visibility_changed():
 ##Internal method for adding a new group, adds a button that controls the visibility of the settings that are connected to this group.
 func _add_group(group_name:String):
 	_group_settings_dict[group_name] = []
-	var group_button = Button.new()
-	group_button.icon = open_section_icon
-	group_button.expand_icon = true
+	var group_button = GROUP_BUTTON_PAINTER.instantiate()
 	group_button.text = group_name
-	group_button.alignment = HORIZONTAL_ALIGNMENT_LEFT
-	group_button.focus_mode = Control.FOCUS_CLICK
-	group_button.flat = true
-	group_button.icon_alignment = HORIZONTAL_ALIGNMENT_LEFT
 	group_button.name = "group_" + group_name
 	group_button.connect("pressed",Callable(self,"_on_group_button_pressed").bind(group_button))
 	_setting_container.add_child(group_button)
 	_group_button_dict[group_name] = group_button
 
+	#Theme seems to be set after being added as a child, if it is inherited. But I call it as deferred to calm my paranoia
+	group_button.call_deferred("calc_min_size")
 
 ##Internal method for controlling the collapsing of the sections.
 func _on_group_button_pressed(button:Button):


### PR DESCRIPTION
The _Group Button_ is the only thing in `SettingsPanel` that is not customizable.  I don't see a clear reason for that, so I added a `Painter` for it.

Also there were some issues with a **focus border**:
![image](https://github.com/user-attachments/assets/fda915d0-1e9c-476b-80da-b56de6d209e5)
Because `Container's Horizontal Sizing` is set to `Fill`, it doesn't look good.
If I change it to `Shrink Begin`, the icon dissapears!

![image](https://github.com/user-attachments/assets/c659f131-c2fb-48cd-b40f-c6512a83ad60)

Some **min size recalculation** was needed. I also connected it with `property_list_changed` and `theme_changed` because I believe scripts can change the size of the text/separation/icon this way. I am a Godot's novice, so I don't claim this is a solid bug-resistant code, but it's better than nothing and the min calculations **can be disabled**, if something happens (there is an exported variable).

Now it looks like this:
![image](https://github.com/user-attachments/assets/fe57c5b8-b282-4702-81d2-6ae5aab3a3ff)
